### PR TITLE
Add streamedResponseAjax for incremental response-body reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Rikulo Commons Changes
 
+### 9.1.0
+
+* Added `streamedResponseAjax()` — the streaming-*response* counterpart
+  to `ajax()`: the caller reads the response body incrementally (e.g.
+  Server-Sent Events) via the `http.StreamedResponse.stream`, with the
+  same force-close timeout.
+
 ### 9.0.1
 
 * Deprecated `HttpUtil`. Use the top-level `decodeQueryString`

--- a/lib/src/io/http_util.dart
+++ b/lib/src/io/http_util.dart
@@ -30,10 +30,10 @@ Future<http.Response> ajax(Uri url, {String method = "GET",
 => _ajax(url, method: method, data: data, body: body, headers: headers,
     timeout: timeout, getResponse: http.Response.fromStream);
 
-Future<http.Response> _ajax(Uri url, {String method = "GET",
+Future<T> _ajax<T>(Uri url, {String method = "GET",
     List<int>? data, String? body, Map<String, String>? headers,
     Duration? timeout,
-    required Future<http.Response> Function(http.StreamedResponse resp)
+    required Future<T> Function(http.StreamedResponse resp)
         getResponse}) {
   assert(data == null || body == null,
       'pass either `data` or `body`, not both');
@@ -47,7 +47,7 @@ Future<http.Response> _ajax(Uri url, {String method = "GET",
   final httpClient = HttpClient();
   final client = http_io.IOClient(httpClient);
 
-  Future<http.Response> doIt() async {
+  Future<T> doIt() async {
     try {
       final request = http.Request(method, url);
       //Apply headers before setting body so that `request.body = ...`
@@ -71,6 +71,34 @@ Future<http.Response> _ajax(Uri url, {String method = "GET",
     throw TimeoutException('ajax($method $url)', timeout);
   });
 }
+
+/// Sends a request and lets the caller read the response body
+/// *incrementally* instead of buffering it — the streaming-response
+/// counterpart to [ajax] (e.g. for Server-Sent Events / chunked
+/// responses).
+///
+/// [onResponse] is given the [http.StreamedResponse]; consume its
+/// [http.StreamedResponse.stream] (parse SSE, forward chunks, …) and
+/// return when done. Its result becomes this call's result.
+///
+/// The connection — and the [timeout] hard force-close — stays alive
+/// until [onResponse] completes; the underlying [HttpClient] is closed
+/// afterward, so don't retain the stream past [onResponse]. As with
+/// [ajax], an exceeded [timeout] force-closes the socket and throws
+/// [TimeoutException].
+///
+/// Unlike [ajax], the status code is NOT pre-checked: an error response
+/// still invokes [onResponse] (the error body may stream in), so inspect
+/// [http.StreamedResponse.statusCode] yourself.
+///
+/// Don't set `Content-Length` in [headers] — it's auto-computed from
+/// the encoded body.
+Future<T> streamedResponseAjax<T>(Uri url,
+    Future<T> Function(http.StreamedResponse resp) onResponse, {
+    String method = "GET", List<int>? data, String? body,
+    Map<String, String>? headers, Duration? timeout})
+=> _ajax(url, method: method, data: data, body: body, headers: headers,
+    timeout: timeout, getResponse: onResponse);
 
 /// Sends an Ajax request to the given [url] using the POST method.
 Future<http.Response> postAjax(Uri url, {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rikulo_commons
-version: 9.0.0
+version: 9.1.0
 description: Collections of common reusable classes and utilities for Dart language.
 homepage: https://github.com/rikulo/commons
 repository: https://github.com/rikulo/commons


### PR DESCRIPTION
## What

Adds `streamedResponseAjax<T>` — the streaming-**response** counterpart to `ajax()`. The caller reads the response body incrementally (e.g. Server-Sent Events / chunked responses) via the `http.StreamedResponse.stream`, with the same hard force-close `timeout:` as `ajax()`.

## Why

`ajax()`/`postAjax()` buffer the whole response (via `http.Response.fromStream`) before returning, and `streamedAjax()` only streams the **request** body. There was no public way to consume a response body as it arrives — needed for SSE/LLM-token streaming where the consumer must see fragments live.

Reaching for `package:http`'s `Client.send()` directly was not an option for callers that need a real timeout: only `ajax()` force-closes the underlying `HttpClient` on timeout (releasing the socket immediately); a bare `.timeout()` leaks the socket until the OS TCP timeout.

## How

The private `_ajax` already received an `http.StreamedResponse` via its `getResponse` callback (the buffering `ajax()` passes `http.Response.fromStream`). This generalizes `_ajax` to `_ajax<T>` and exposes `streamedResponseAjax<T>(url, onResponse, …)`, which hands the caller that same `StreamedResponse` and returns `onResponse`'s result. The connection — and the force-close timeout — stay alive until `onResponse` completes; the client is closed afterward.

- No behavior change to existing callers (`ajax`/`postAjax`/`headAjax` still infer `T = http.Response`).
- Unlike `ajax`, the status code is not pre-checked — the caller inspects `StreamedResponse.statusCode` (an error body may still stream in).
- `dart analyze lib` → no issues.

Bumps to 9.1.0 (additive).